### PR TITLE
feat(msa-rider): user seed rider 삽입 + 전처리 pw 암호화

### DIFF
--- a/msa/user-service/src/main/resources/db/migration/seed/V102__insert_test_users.sql
+++ b/msa/user-service/src/main/resources/db/migration/seed/V102__insert_test_users.sql
@@ -1,0 +1,5 @@
+-- V102__insert_test_users.sql
+-- 테스트용 사용자 데이터
+INSERT INTO `users` (`id`, `email`, `password`, `phone`, `name`, `birth_date`, `user_type`, `is_active`, `email_verified`, `phone_verified`) VALUES
+(5, 'rider1@test.com', 'password123', '01044444444', '김배달', '1990-01-01', 'RIDER', TRUE, TRUE, TRUE),
+(6, 'rider2@test.com', 'password123', '01055555555', '박배달', '1992-05-15', 'RIDER', TRUE, TRUE, TRUE);

--- a/msa/user-service/src/main/resources/db/migration/seed/V103__update_test_user_passwords.sql
+++ b/msa/user-service/src/main/resources/db/migration/seed/V103__update_test_user_passwords.sql
@@ -1,0 +1,8 @@
+-- V103__update_test_user_passwords
+-- Encrypt user passwords.
+UPDATE users SET password='$2b$10$REwoD5OB40AAUyPubK7Lp.lwisqSLmTDdVvRDXHOtbsTW.u82MNpy' WHERE id=1;
+UPDATE users SET password='$2b$10$hc/h4vBGixp3Qny1zqQyQu6trQSqzOxGCkMWzk/dN7Y1fO583VYYm' WHERE id=2;
+UPDATE users SET password='$2b$10$Vx6weAZyx5hQ8M6BJ8OAneHz6FDtFIVM/e86RpwLwueaIrmwEQPMW' WHERE id=3;
+UPDATE users SET password='$2b$10$.9oGljVBahycz03lE0wueuWveYMp3ADrVAaBDZhQo.ILYTUcBZk.q' WHERE id=4;
+UPDATE users SET password='$2b$10$oebsPNnxuxQAYxeKCrthjudnYT2T33PEeZxpqjHMmknh5AMC0g0nO' WHERE id=5;
+UPDATE users SET password='$2b$10$uTPo6RMKOfhjhXVTR9pgGOCr3lfXc4BU6P0zVnDF1RtoJg8qpR1FW' WHERE id=6;


### PR DESCRIPTION
[BACKEND]
1. user-service db seed V102(rider1@test.com, rider2@test.com)
2. user-service db seed V103(Encrypt user passwords.)
[FRONTEND]
fix: display only data field instead of entire response object in today-(avg,count,income) card
